### PR TITLE
Added debug_log param to run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ git.run(:pull, 'origin', 'master', timeout: 2) # override default timeout of 10
 git.run(:status) # will raise an error because :status is not in list of allowed commands 
 ```
 
+Debugging and Logging
+---------
+If you need insight to what commands you're running you can pass CommandRunner an object responding to :puts
+such as $stdout, $stderr, the writing and of an IO.pipe, or a file opened for writing. CommandRunnerNG will
+log start, stop, end timeouts. Eg:
+
+```rb
+require 'command_runner'
+
+CommandRunner.run('ls /tmp', debug_log: $stdout)
+# Outputs:
+# CommandRunnerNG spawn: args=["ls /tmp"], timeout=, options: {:err=>[:child, :out]}, PID: 10973
+# CommandRunnerNG exit: PID: 10973, code: 0
+
+my_log = File.open('log.txt, 'a')
+CommandRunner.run('ls /tmp', debug_log: my_log) # Log appended to a file
+```
+
+
+
 Why?
 ----
 We have used too many subtly broken approaches to handling child processes in many different projects. In particular

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ git.run(:status) # will raise an error because :status is not in list of allowed
 
 Debugging and Logging
 ---------
-If you need insight to what commands you're running you can pass CommandRunner an object responding to :puts
-such as $stdout, $stderr, the writing and of an IO.pipe, or a file opened for writing. CommandRunnerNG will
-log start, stop, end timeouts. Eg:
+If you need insight to what commands you're running you can pass CommandRunner an object responding to ```:puts```
+such as $stdout, $stderr, the writing end of an IO.pipe, or a file opened for writing. CommandRunnerNG will
+log start, stop, and timeouts. Eg:
 
 ```rb
 require 'command_runner'
@@ -70,6 +70,10 @@ my_log = File.open('log.txt, 'a')
 CommandRunner.run('ls /tmp', debug_log: my_log) # Log appended to a file
 ```
 
+Or you can enable debug logging for all command line invocations like this:
+```rb
+CommandRunner.set_debug_log!($stderr)
+```
 
 
 Why?

--- a/lib/command_runner.rb
+++ b/lib/command_runner.rb
@@ -49,9 +49,14 @@ module CommandRunner
   #
   # Debugging: To help debugging your app you can set the debug_log parameter. It can be any old object responding
   # to :puts. Fx. $stderr, $stdout, or the write end of an IO.pipe. CommandRunnerNG will put some info about
-  # all process start, stop, and timeouts here.
+  # all process start, stop, and timeouts here. To enable debug logging for all commands call
+  # CommandRunner.set_debug_log!($stderr) (or with some other object responding to :puts).
   #
   def self.run(*args, timeout: nil, environment: {}, debug_log: nil, options: DEFAULT_OPTIONS)
+    if debug_log.nil?
+      debug_log = @@global_debug_log
+    end
+
     # If args is an array of strings, allow that as a shorthand for [arg1, arg2, arg3]
     if args.length > 1 && args.all? {|arg| arg.is_a? String}
       args = [args]
@@ -156,7 +161,20 @@ module CommandRunner
     CommandInstance.new(args, timeout, environment, allowed_sub_commands, debug_log, options)
   end
 
+  # Log all command line invocations to a logger object responding to :puts. Set to nil to disable.
+  # Setting the :debug_log keyword argument on individual invocations of CommandRunner.run() overrides this value.
+  def self.set_debug_log!(logger)
+    if logger.respond_to?(:puts) || logger.nil?
+      @@global_debug_log = logger
+    else
+      raise ArgumentError.new("Logger '#{logger}' not responding to :puts")
+    end
+  end
+
   private
+
+  # Set to an object that respond to :puts to enable global debug logging for all
+  @@global_debug_log = nil
 
   class CommandInstance
 

--- a/test/test_command_runner.rb
+++ b/test/test_command_runner.rb
@@ -125,6 +125,18 @@ class TestCommandRunner < Test::Unit::TestCase
     assert_equal 0, result[:status].exitstatus
   end
 
+  def test_debug_log
+    rd, wr = IO.pipe
+    result = CommandRunner.run('ls', 'test', debug_log: wr)
+    wr.close
+
+    assert result[:out].start_with?("test_command_runner"), "Unexpected output: #{result[:out]}"
+    assert_equal 0, result[:status].exitstatus
+    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
+  ensure
+    rd.close
+  end
+
   # Test disabled as it requires thin.
   # Most perculiar behaviour have been observed when backgrounding thin through a subshell.
   # Note that correct usage would be to daemonize it with -d.

--- a/test/test_command_runner_create.rb
+++ b/test/test_command_runner_create.rb
@@ -80,4 +80,15 @@ class TestCommandRunner < Test::Unit::TestCase
     assert_equal 0, result[:status].exitstatus
     assert_equal "hello mundo\n", result[:out]
   end
+
+  def test_debug_log
+    rd, wr = IO.pipe
+    ls = CommandRunner.create(['ls'], debug_log: wr)
+
+    result = ls.run('test')
+    wr.close
+    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
+  ensure
+    rd.close
+  end
 end


### PR DESCRIPTION
Accepts any old object responding to :puts. Fx. $stderr, $stdout, or the writing end of a IO.pipe. Prints start, stop, and timeout messages here. Works both in instanced and static mode.

Fixes https://github.com/kamstrup/command_runner_ng/issues/9

CC: @sapieneptus