### PR TITLE
Feature/encode output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ If you just want to silence stderr you can override all standard Kernel.spawn op
 CommandRunner.run(['ls', '/nosuchdir'], options: {err: '/dev/null})
 ```
 
+Encoding
+-----------
+If you need to ensure safely encoded output - you can force UTF-8 encoding by passing the :safe symbol. Eg:
+``rb
+require 'command_runner'
+result = CommandRunner.run('echo hellò', encoding: :safe) # => {out: 'hellò\n'}
+```
+
+By default we don't apply any encoding changed to the output.
+
 Debugging and Logging
 ---------
 If you need insight to what commands you're running you can pass CommandRunner an object responding to ```:puts```

--- a/lib/command_runner.rb
+++ b/lib/command_runner.rb
@@ -178,13 +178,15 @@ module CommandRunner
   def self.ensure_command_output_encoded(string, command, encoding = nil)
     return '' if !string
 
-    return string if encoding.nil?
+    return string if encoding.nil? ||  encoding != :safe
 
-    firstPass = string.force_encoding(encoding)
+    encodingName = 'UTF-8'
+
+    firstPass = string.force_encoding(encodingName)
 
     return firstPass if firstPass.valid_encoding?
 
-    encoded = firstPass.encode(encoding, encoding,
+    encoded = firstPass.encode(encodingName, encodingName,
                           invalid: :replace,
                           undef: :replace,
                           replace: "")
@@ -192,7 +194,7 @@ module CommandRunner
     return encoded if encoded.valid_encoding?
 
     raise EncodingError, %Q{
-      Could not force #{encoding} encoding on this string:
+      Could not force #{encodingName} encoding on this string:
       #{string}
       which is the output of this command:
       #{command}

--- a/test/test_command_runner.rb
+++ b/test/test_command_runner.rb
@@ -34,6 +34,18 @@ class TestCommandRunner < Test::Unit::TestCase
     assert_equal 0, result[:status].exitstatus
   end
 
+  def test_utf8_shell_echo
+    result = CommandRunner.run(['echo', 'hellò'], encoding: "UTF-8")
+    assert_equal "hellò\n", result[:out]
+    assert_equal 0, result[:status].exitstatus
+  end
+
+  def test_utf8_split_err
+    result = CommandRunner.run('echo ÒUT ; echo ÊRR 1>&2', split_stderr: true, encoding: "UTF-8")
+    assert_equal "ÒUT\n", result[:out]
+    assert_equal "ÊRR\n", result[:err]
+  end
+
   def test_shell_echo_sleep_timeout
     result = CommandRunner.run('echo hello && sleep 5', timeout: 2)
     assert_equal "hello\n", result[:out]
@@ -132,7 +144,7 @@ class TestCommandRunner < Test::Unit::TestCase
 
     assert result[:out].start_with?("test_command_runner"), "Unexpected output: #{result[:out]}"
     assert_equal 0, result[:status].exitstatus
-    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
+    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, encoding=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
   ensure
     rd.close
   end

--- a/test/test_command_runner.rb
+++ b/test/test_command_runner.rb
@@ -35,13 +35,13 @@ class TestCommandRunner < Test::Unit::TestCase
   end
 
   def test_utf8_shell_echo
-    result = CommandRunner.run(['echo', 'hellò'], encoding: "UTF-8")
+    result = CommandRunner.run(['echo', 'hellò'], encoding: :safe)
     assert_equal "hellò\n", result[:out]
     assert_equal 0, result[:status].exitstatus
   end
 
   def test_utf8_split_err
-    result = CommandRunner.run('echo ÒUT ; echo ÊRR 1>&2', split_stderr: true, encoding: "UTF-8")
+    result = CommandRunner.run('echo ÒUT ; echo ÊRR 1>&2', split_stderr: true, encoding: :safe)
     assert_equal "ÒUT\n", result[:out]
     assert_equal "ÊRR\n", result[:err]
   end

--- a/test/test_command_runner_create.rb
+++ b/test/test_command_runner_create.rb
@@ -87,7 +87,7 @@ class TestCommandRunner < Test::Unit::TestCase
 
     result = ls.run('test')
     wr.close
-    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
+    assert_equal "CommandRunnerNG spawn: args=[[\"ls\", \"test\"]], timeout=, encoding=, options: {:err=>[:child, :out]}, PID: #{result[:pid]}\nCommandRunnerNG exit: PID: #{result[:pid]}, code: 0\n", rd.read
   ensure
     rd.close
   end


### PR DESCRIPTION
### Motivation
Gives us the ability to specify that we want to use a `:safe` encoding for the output. [Based on this feature discussion](https://github.com/kamstrup/command_runner_ng/issues/12#issuecomment-393780110)

I haven't implemented the streaming using `Encoding::Converter` because I seem to remember @kamstrup saying it was broken / badly documented - but I wanted to pass through what I've got so far.

### Encoding Functionality
If you need to ensure safely encoded output - you can force UTF-8 encoding by passing the :safe symbol. Eg:
```
require 'command_runner'
result = CommandRunner.run('echo hellò', encoding: :safe) # => {out: 'hellò\n'}
```

By default we don't apply any encoding changed to the output.

### Tests
I've tested only success cases at the moment. Do we want to also test cases where we can't encode? If so - which edge cases do we want to test?